### PR TITLE
Shorten the command require to launch the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # Mongostead7
 A bash script to install MongoDB on Laravel Homestead with php7
 ## Usage
-Use the following commands:
+Use the following command:
 
-`git clone https://github.com/zakhttp/Mongostead7.git`
-
-`cd Mongostead7`
-
-`chmod +x mongoHomestead7.sh`
-
-`./mongoHomestead7.sh`
+`sudo curl -sS https://raw.githubusercontent.com/zakhttp/Mongostead7/master/mongoHomestead7.sh | sudo sh`
 
 Cheers!


### PR DESCRIPTION
I suggest a single command to trigger the installation of MongoDB.
